### PR TITLE
Use 'sendPluginResult' on iOS.

### DIFF
--- a/src/ios/Insomnia.m
+++ b/src/ios/Insomnia.m
@@ -13,7 +13,7 @@
     [app setIdleTimerDisabled:true];
   }
   CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-  [self writeJavascript:[result toSuccessCallbackString:callbackId]];
+  [self.commandDelegate sendPluginResult:result callbackId:callbackId];
 }
 
 - (void) allowSleepAgain:(CDVInvokedUrlCommand*)command {
@@ -26,7 +26,7 @@
     [app setIdleTimerDisabled:false];
   }
   CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-  [self writeJavascript:[result toSuccessCallbackString:callbackId]];
+  [self.commandDelegate sendPluginResult:result callbackId:callbackId];
 }
 
 @end


### PR DESCRIPTION
`writeJavascript` has been deprecated, so use the newer API to shut up the deprecation warnings (and make it forward-compatible).
