### PR TITLE
Add error support for browser platform

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,6 +56,12 @@
     <source-file src="src/android/nl/xservices/plugins/Insomnia.java" target-dir="src/nl/xservices/plugins"/>
   </platform>
 
+  <platform name="browser">
+    <js-module src="src/browser/Insomnia.js" name="InsomniaProxy">
+      <merges target="window.plugins.insomnia" />
+    </js-module>
+  </platform>
+
   <!-- firefoxos -->
   <platform name="firefoxos">
     <js-module src="src/firefoxos/insomnia.js" name="InsomniaProxy">

--- a/src/browser/Insomnia.js
+++ b/src/browser/Insomnia.js
@@ -1,0 +1,10 @@
+function notSupported() {
+    console.log('Insomnia is not supported on the browser');
+}
+
+module.exports = {
+    keepAwake: notSupported,
+    allowSleepAgain: notSupported
+};
+
+require('cordova/exec/proxy').add('Insomnia', module.exports);


### PR DESCRIPTION
Hi Eddy, I am in the process of adding basic browser support to the [PhoneGap Developer App](https://github.com/phonegap/phonegap-app-developer) and in doing so need to have proper error handling for all plugins that are not supported on browser. This is just so we do not leave any stray errors that may break our app if the functionality is not present.
